### PR TITLE
Include stock snippets config suggestion in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Use `VimCompleteLikeAModernEditor` to add keyboard interactions to `Ultisnips` a
         Bundle "jordwalke/VimCompleteLikeAModernEditor"
 
         " Place snippets in ~/.vim/myUltiSnippets/
+        " Or if want to use stock snippets too...
+        " let g:UltiSnipsSnippetDirectories=["myUltiSnips", "UltiSnips"]
         
         " Put this in your .vimrc
         " let g:UltiSnipsExpandTrigger="<tab>"


### PR DESCRIPTION
Let users know that if they want to keep stock snippets, it is easy enough
to configure so.
Discarding the default snips seemed like a radical step to me, and I was glad to find that it was easy to de-configure that.
